### PR TITLE
Update the handbook to cover a few controversial topics

### DIFF
--- a/docs/handbook/About/3-PublicBenefits.md
+++ b/docs/handbook/About/3-PublicBenefits.md
@@ -28,3 +28,21 @@ We are.
 The single greatest advantage Ondsel has over closed source competitors is the open source core itself. This makes it easier and less risky for potential customers to try the tool since vendor-lockin is minimized.
 
 Because of this, we have a vested interest in the long-term health of FreeCAD and related FOSS projects.
+
+## What does Ondsel do to stay a positive force in the FreeCAD ecosystem?
+
+### The company should be contributing their changes back to the upstream project.
+
+Over the course of v0.21 development cycle, Ondsel submitted over 20 pull requests, all were merged by respective maintainers after code review. For v1.0, Ondsel has already contributed an integrated assembly workbench (work in progress) and a kinematic solver, as well as various quality-of-life improvements.
+
+### The company shouldn't get a special treatment when contributing to FreeCAD.
+
+Patches by Ondsel land into the same pull request queue as patches by other contributors. These patches go through the same review process and, after further improvements where applicable, are merged by respective maintainers who are not Ondsel employees. The only patches that the Ondsel team merges are the ones for the Path workbench where Brad Collette is the maintainer.
+
+### None of the Ondsel employees should have a conflict of interest between Ondsel, FreeCAD, and the FreeCAD Project Association.
+
+Multiple Ondsel employees are FreeCAD developers. However only one Ondsel employee, Brad Collette, is also a FreeCAD maintainer and a board member of the FreeCAD Project Association. While he has voting rights in the FPA, he represents a minority whose voting can be easily overturned. As a FreeCAD maintainer, he provides code review for patches outside of his personal scope of interest, but ultimately only merges patches to the Path workbench.
+
+### Ondsel shouldn't be able to make unilateral decisions on the rules of participation at the FreeCAD project.
+
+While the initial revision of CONTRIBUTING.md comes from Brad Collette, that document was created prior to launching Ondsel and receieved further revisions from contributors who are not Ondsel employees.


### PR DESCRIPTION
- How the company contributes back to upstream FreeCAD (amount of accepted pull requests + notable contributions)
- Whether the company gets a special treatment when contributing to FreeCAD (no)
- Whether Ondsel employees have a conflict of interest (unlikely)
- Whether Ondsel is able to make unilateral decisions on the rules of participation at the FreeCAD project (no)