### PR TITLE
Download page: reorder appimages and add intel- prefix to x86_64 dmg

### DIFF
--- a/src/components/DownloadList/index.js
+++ b/src/components/DownloadList/index.js
@@ -24,12 +24,12 @@ export default function DownloadList({ assets }) {
   const [showMacos, setShowMacos] = useState(false);
   const [showWin, setShowWin] = useState(false);
 
-  let linux = ['aarch64', 'x86_64'];
+  let linux = ['x86_64', 'aarch64'];
   linux = linux.map( (e) => { 
     return parseDL( assets, e, 'AppImage' );
   });
 
-  let macos = ['arm64', 'x86_64'];
+  let macos = ['arm64', 'intel-x86_64'];
   macos = macos.map( (e) => {
     return parseDL( assets, e, 'dmg' );
   })


### PR DESCRIPTION
x86_64 appimage should be first on the list as it is way more widely used than aarch64

regular macOS user don't normally know what x86_64 and arm64 mean as apple never uses those, instead they know them as "intel" and "apple silicon", apple silicon should now be the first choice. Adding intel- prefix to the x86_64 dmg should make things clearer